### PR TITLE
Fix promise section scroll link

### DIFF
--- a/src/components/PromiseSection.tsx
+++ b/src/components/PromiseSection.tsx
@@ -37,7 +37,7 @@ export default function PromiseSection() {
   };
   return (
     <motion.section
-      id="testimonials"
+      id="promise"
       className="promise-section relative w-full h-screen flex flex-col justify-center items-center text-center px-6 overflow-hidden"
     >
       <h2 className="text-3xl font-bold mb-4 text-[var(--light-text)]">
@@ -90,7 +90,7 @@ export default function PromiseSection() {
       </div>
               {/* Simple down chevron */}
         <motion.div
-        onClick={() => scrollToSection("Testimonials")}
+        onClick={() => scrollToSection("testimonials")}
         className="absolute bottom-6 left-1/2 transform -translate-x-1/2 cursor-pointer"
         animate={{ y: [0, -5, 0] }}
         transition={{ repeat: Infinity, duration: 2 }}


### PR DESCRIPTION
## Summary
- fix id on PromiseSection to avoid duplicate `testimonials` id
- ensure arrow scrolls to testimonials section

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874de096ec0832b8a9f106d030a05bf